### PR TITLE
Updates to match latest documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
 ## 0.1.0 (July 28, 2021)
 
 * Initial release
+
+## 0.1.1 (August 13, 2021)
+
+* Update config and file permissions to match Deployment Guide
+* Update disk specs to new Reference Architecture recommendations
+* Update default version to 1.8.1

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ provider "aws" {
 
 module "vault-ent" {
   source  = "hashicorp/vault-ent-starter/aws"
-  version = "0.1.0"
+  version = "0.1.1"
 
   # prefix for tagging/naming AWS resources
   resource_name_prefix = "test"

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -128,8 +128,10 @@ resource "aws_launch_template" "vault" {
     device_name = "/dev/sda1"
 
     ebs {
-      volume_type           = "gp2"
-      volume_size           = 50
+      volume_type           = "gp3"
+      volume_size           = 100
+      throughput            = 150
+      iops                  = 3000
       delete_on_termination = true
     }
   }

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "vault_license_name" {
 
 variable "vault_version" {
   type        = string
-  default     = "1.8.0"
+  default     = "1.8.1"
   description = "Vault version"
 }
 


### PR DESCRIPTION
Make some updates to match the latest documentation:
* Update config and file permissions to match Deployment Guide
* Update disk specs to new Reference Architecture recommendations
* Update default version to 1.8.1