### PR TITLE
Local TLS usage updates and IMDSv2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.2 (August 20, 2021)
+## 0.1.2 (August 19, 2021)
 
 * Update TLS directory permissions
 * Remove client cert and key from profile script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,17 @@
-## 0.1.0 (July 28, 2021)
+## 0.1.2 (August 20, 2021)
 
-* Initial release
+* Update TLS directory permissions
+* Remove client cert and key from profile script
+* Update indentation in configuration file
+* Enable EC2 IMDSv2 tokens in launch template
+* Support using EC2 IMDSv2 in user-data script
 
 ## 0.1.1 (August 13, 2021)
 
 * Update config and file permissions to match Deployment Guide
 * Update disk specs to new Reference Architecture recommendations
 * Update default version to 1.8.1
+
+## 0.1.0 (July 28, 2021)
+
+* Initial release

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ provider "aws" {
 
 module "vault-ent" {
   source  = "hashicorp/vault-ent-starter/aws"
-  version = "0.1.1"
+  version = "0.1.2"
 
   # prefix for tagging/naming AWS resources
   resource_name_prefix = "test"

--- a/modules/user_data/templates/install_vault.sh.tpl
+++ b/modules/user_data/templates/install_vault.sh.tpl
@@ -16,6 +16,9 @@ timedatectl set-timezone UTC
 # removing any default installation files from /opt/vault/tls/
 rm -rf /opt/vault/tls/*
 
+# /opt/vault/tls should be readable by all users of the system
+chmod 0755 /opt/vault/tls
+
 # vault-key.pem should be readable by the vault group only
 touch /opt/vault/tls/vault-key.pem
 chown root:vault /opt/vault/tls/vault-key.pem
@@ -84,6 +87,4 @@ echo "Setup Vault profile"
 cat <<PROFILE | sudo tee /etc/profile.d/vault.sh
 export VAULT_ADDR="https://127.0.0.1:8200"
 export VAULT_CACERT="/opt/vault/tls/vault-ca.pem"
-export VAULT_CLIENT_CERT="/opt/vault/tls/vault-cert.pem"
-export VAULT_CLIENT_KEY="/opt/vault/tls/vault-key.pem"
 PROFILE

--- a/modules/user_data/templates/install_vault.sh.tpl
+++ b/modules/user_data/templates/install_vault.sh.tpl
@@ -59,11 +59,11 @@ cluster_addr = "https://$local_ipv4:8201"
 api_addr = "https://$local_ipv4:8200"
 
 listener "tcp" {
- address     = "0.0.0.0:8200"
- tls_disable = false
- tls_cert_file      = "/opt/vault/tls/vault-cert.pem"
- tls_key_file       = "/opt/vault/tls/vault-key.pem"
- tls_client_ca_file = "/opt/vault/tls/vault-ca.pem"
+  address            = "0.0.0.0:8200"
+  tls_disable        = false
+  tls_cert_file      = "/opt/vault/tls/vault-cert.pem"
+  tls_key_file       = "/opt/vault/tls/vault-key.pem"
+  tls_client_ca_file = "/opt/vault/tls/vault-ca.pem"
 }
 
 seal "awskms" {

--- a/modules/user_data/templates/install_vault.sh.tpl
+++ b/modules/user_data/templates/install_vault.sh.tpl
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
-export instance_id="$(curl -s http://169.254.169.254/latest/meta-data/instance-id)"
-export local_ipv4="$(curl -s http://169.254.169.254/latest/meta-data/local-ipv4)"
+imds_token=$( curl -Ss -H "X-aws-ec2-metadata-token-ttl-seconds: 30" -XPUT 169.254.169.254/latest/api/token )
+instance_id=$( curl -Ss -H "X-aws-ec2-metadata-token: $imds_token" 169.254.169.254/latest/meta-data/instance-id )
+local_ipv4=$( curl -Ss -H "X-aws-ec2-metadata-token: $imds_token" 169.254.169.254/latest/meta-data/local-ipv4 )
 
 # install package
 

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -139,6 +139,11 @@ resource "aws_launch_template" "vault" {
   iam_instance_profile {
     name = var.aws_iam_instance_profile
   }
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
 }
 
 resource "aws_autoscaling_group" "vault" {


### PR DESCRIPTION
These changes update permissions and environment variables to allow safer interaction with Vault by operators using a the localhost CLI.

This also enables enforcement of [IMDSv2 metadata API](https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/) usage for better anti-SSRF protection.