### PR TITLE
Include Vault security group ID as output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,8 @@ output "vault_target_group_arn" {
   description = "Target group ARN to register Vault nodes with"
   value       = module.loadbalancer.vault_target_group_arn
 }
+
+output "vault_sg_id" {
+  description = "Security group ID of Vault cluster"
+  value       = module.vm.vault_sg_id
+}


### PR DESCRIPTION
This PR adds the vm module's `vault_sg_id` output as a top-level module output. I would like to see this additional output include to allow for an easier time adding security group rules for Vault (outside, and in addition to, what the module overall already does).