### PR TITLE
Add `additional_lb_target_groups` Input Variable

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,13 @@ module "user_data" {
   vault_version               = var.vault_version
 }
 
+locals {
+  vault_target_group_arns = concat(
+    [module.loadbalancer.vault_target_group_arn],
+    var.additional_lb_target_groups,
+  )
+}
+
 module "vm" {
   source = "./modules/vm"
 
@@ -82,6 +89,6 @@ module "vm" {
   user_supplied_ami_id      = var.user_supplied_ami_id
   vault_lb_sg_id            = module.loadbalancer.vault_lb_sg_id
   vault_subnets             = module.networking.vault_subnet_ids
-  vault_target_group_arn    = module.loadbalancer.vault_target_group_arn
+  vault_target_group_arns   = local.vault_target_group_arns
   vpc_id                    = module.networking.vpc_id
 }

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -152,7 +152,7 @@ resource "aws_autoscaling_group" "vault" {
   max_size            = var.node_count
   desired_capacity    = var.node_count
   vpc_zone_identifier = var.vault_subnets
-  target_group_arns   = [var.vault_target_group_arn]
+  target_group_arns   = var.vault_target_group_arns
 
   launch_template {
     id      = aws_launch_template.vault.id

--- a/modules/vm/variables.tf
+++ b/modules/vm/variables.tf
@@ -70,9 +70,9 @@ variable "vault_subnets" {
   description = "Private subnets where Vault will be deployed"
 }
 
-variable "vault_target_group_arn" {
-  type        = string
-  description = "Target group ARN to register Vault nodes with"
+variable "vault_target_group_arns" {
+  type        = list(string)
+  description = "Target group ARN(s) to register Vault nodes with"
 }
 
 variable "vpc_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "allowed_inbound_cidrs_ssh" {
   default     = null
 }
 
+variable "additional_lb_target_groups" {
+  type        = list(string)
+  description = "(Optional) List of load balancer target groups to associate with the Vault cluster. These target groups are _in addition_ to the LB target group this module provisions by default."
+  default     = []
+}
+
 variable "common_tags" {
   type        = map(string)
   description = "(Optional) Map of common tags for all taggable AWS resources."


### PR DESCRIPTION
This PR tweaks the `vm` module's `vault_target_group_arn` input variable to accept a _list_ of target group ARNs. Alongside a related `additional_lb_target_groups` input variable additional to the top-level of the module. This change is desired to allow the association of more than one ELB target group with the Vault cluster / ASG. 

In our use case, we have this module provision a NLB per the existing config _and_ also an ALB that is provisioned outside the module for a slightly different purposes. Specifically, we have the NLB provisioned to enable a VPC endpoint service for Vault but also want an ID-aware ALB pointed at the cluster (NLB / endpoint for machine users and the ALB for human users).