### PR TITLE
Add kms_key_arn output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "kms_key_arn" {
+  value = module.kms.kms_key_arn
+}
+
 output "vault_lb_dns_name" {
   description = "DNS name of Vault load balancer"
   value       = module.loadbalancer.vault_lb_dns_name


### PR DESCRIPTION
T'would be handy to have this value as an output. E.g., in cases where folks want to bring their own Vault IAM role but are fine with the module handling the associated KMS key's lifecycle.