### PR TITLE
Pass in subnet IDs explictly

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,7 @@ on AWS using the Enterprise version of Vault 1.8+.
   - Three public subnets
   - Three [NAT
     gateways](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) (one in each public subnet)
-  - Three private subnets (please make sure your private subnets are
-    specifically tagged so you can identify them. The Vault module will use
-    these tags to deploy the Vault servers into them.)
+  - Three private subnets
 
 - Use the
   [example](https://github.com/hashicorp/terraform-aws-vault-ent-starter/tree/main/examples/aws-secrets-manager-acm)
@@ -65,11 +63,9 @@ module "vault-ent" {
   resource_name_prefix = "test"
   # VPC ID you wish to deploy into
   vpc_id = "vpc-abc123xxx"
-  # private subnet tags are required and allow you to filter which
+  # private subnet IDs are required and allow you to specify which
   # subnets you will deploy your Vault nodes into
-  private_subnet_tags = {
-    Vault = "deploy"
-  }
+  private_subnet_ids = ["subnet-0d75d14952ac68ec3"]
   # AWS Secrets Manager ARN where TLS certs are stored
   secrets_manager_arn = "arn:aws::secretsmanager:abc123xxx"
   # The shared DNS SAN of the TLS certs being used

--- a/main.tf
+++ b/main.tf
@@ -27,7 +27,7 @@ module "loadbalancer" {
   common_tags           = var.common_tags
   lb_certificate_arn    = var.lb_certificate_arn
   lb_health_check_path  = var.lb_health_check_path
-  lb_subnets            = module.networking.vault_subnet_ids
+  lb_subnets            = var.private_subnet_ids
   lb_type               = var.lb_type
   resource_name_prefix  = var.resource_name_prefix
   ssl_policy            = var.ssl_policy
@@ -38,8 +38,7 @@ module "loadbalancer" {
 module "networking" {
   source = "./modules/networking"
 
-  private_subnet_tags = var.private_subnet_tags
-  vpc_id              = var.vpc_id
+  vpc_id = var.vpc_id
 }
 
 module "object_storage" {
@@ -81,7 +80,7 @@ module "vm" {
   userdata_script           = module.user_data.vault_userdata_base64_encoded
   user_supplied_ami_id      = var.user_supplied_ami_id
   vault_lb_sg_id            = module.loadbalancer.vault_lb_sg_id
-  vault_subnets             = module.networking.vault_subnet_ids
+  vault_subnets             = var.private_subnet_ids
   vault_target_group_arn    = module.loadbalancer.vault_target_group_arn
   vpc_id                    = module.networking.vpc_id
 }

--- a/modules/networking/README.md
+++ b/modules/networking/README.md
@@ -2,7 +2,6 @@
 
 ## Required variables
 
-* `private_subnet_tags` - Tags which specify the subnets to deploy Vault into
 * `vpc_id` - VPC ID where Vault will be deployed
 
 ## Example usage
@@ -11,7 +10,6 @@
 module "networking" {
   source = "./modules/networking"
 
-  private_subnet_tags = var.private_subnet_tags
-  vpc_id              = var.vpc_id
+  vpc_id = var.vpc_id
 }
 ```

--- a/modules/networking/main.tf
+++ b/modules/networking/main.tf
@@ -1,8 +1,3 @@
 data "aws_vpc" "selected" {
   id = var.vpc_id
 }
-
-data "aws_subnet_ids" "vault" {
-  vpc_id = data.aws_vpc.selected.id
-  tags   = var.private_subnet_tags
-}

--- a/modules/networking/outputs.tf
+++ b/modules/networking/outputs.tf
@@ -1,7 +1,3 @@
-output "vault_subnet_ids" {
-  value = data.aws_subnet_ids.vault.ids
-}
-
 output "vpc_id" {
   value = data.aws_vpc.selected.id
 }

--- a/modules/networking/variables.tf
+++ b/modules/networking/variables.tf
@@ -1,8 +1,3 @@
-variable "private_subnet_tags" {
-  type        = map(string)
-  description = "Tags which specify the subnets to deploy Vault into"
-}
-
 variable "vpc_id" {
   type        = string
   description = "VPC ID where Vault will be deployed"

--- a/modules/vm/main.tf
+++ b/modules/vm/main.tf
@@ -52,8 +52,8 @@ resource "aws_security_group_rule" "vault_internal_raft" {
 # (which are the private subnets the Vault instances use)
 
 data "aws_subnet" "subnet" {
-  for_each = toset(var.vault_subnets)
-  id       = each.value
+  count = length(var.vault_subnets)
+  id    = var.vault_subnets[count.index]
 }
 
 locals {

--- a/variables.tf
+++ b/variables.tf
@@ -67,9 +67,9 @@ variable "node_count" {
   description = "Number of Vault nodes to deploy in ASG"
 }
 
-variable "private_subnet_tags" {
-  type        = map(string)
-  description = "Tags which specify the subnets to deploy Vault into"
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs to deploy Vault into"
 }
 
 variable "resource_name_prefix" {


### PR DESCRIPTION
To avoid this sort of deal in scenarios where this module and
corresponding VPC are being created within the same run:

```
╷
│ Error: Invalid for_each argument
│
│   on .terraform/modules/vault-ent/modules/vm/main.tf line 55, in data
"aws_subnet" "subnet":
│   55:   for_each = toset(var.vault_subnets)
│     ├────────────────
│     │ var.vault_subnets is a list of string, known only after apply
│
│ The "for_each" value depends on resource attributes that cannot be
│ determined until apply, so Terraform cannot predict how many instances
will
│ be created. To work around this, use the -target argument to first
apply
│ only the resources that the for_each depends on.
```

I won't claim that this is the best "fix" for avoiding the stated issue but it is _a_ fix perhaps? :P