### PR TITLE
Removed config line that disabled performance standby nodes

### DIFF
--- a/modules/user_data/templates/install_vault.sh.tpl
+++ b/modules/user_data/templates/install_vault.sh.tpl
@@ -39,7 +39,6 @@ chown root:vault /opt/vault/vault.hclic
 chmod 0640 /opt/vault/vault.hclic
 
 cat << EOF > /etc/vault.d/vault.hcl
-disable_performance_standby = true
 ui = true
 disable_mlock = true
 


### PR DESCRIPTION
the default setting is `true` so we don't need this line to be explicitly setting to `true` (after changing from `false`)